### PR TITLE
Support plus

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -59,20 +59,26 @@ const AuthModal = ({
             <ModalContent>
                 <ModalHeader>Please log in</ModalHeader>
                 <ModalBody>
-                    <Button onClick={() => login()}>Log in with Google</Button>
                     <Center>
-                        {" "}
-                        <Heading size="sm"> or </Heading>{" "}
+                        <Button onClick={() => login()}>Log in with Google</Button>
+                        <Heading size="sm"> or </Heading>
+                        <br />
+                        <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
+                        <InputGroup size="sm" w={"60%"}>
+                            <Input
+                                placeholder="example@mail.com"
+                                type="email"
+                                ref={emailInput}
+                                variant="filled"
+                                p={2}
+                            />
+                            <InputRightElement width="4.5rem" p={2}>
+                                <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>
+                                    Submit
+                                </Button>
+                            </InputRightElement>
+                        </InputGroup>
                     </Center>
-                    <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
-                    <InputGroup size="sm">
-                        <Input placeholder="example@mail.com" type="email" ref={emailInput} variant="filled" p={2} />
-                        <InputRightElement width="4.5rem">
-                            <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>
-                                Submit
-                            </Button>
-                        </InputRightElement>
-                    </InputGroup>
                 </ModalBody>
                 <ModalFooter />
             </ModalContent>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -10,6 +10,7 @@ import {
     Input,
     Text,
     InputRightElement,
+    InputGroup,
 } from "@chakra-ui/react"
 import { useGoogleLogin } from "@react-oauth/google"
 import { queryClient, useCheckWhitelist } from "../util"
@@ -48,7 +49,8 @@ const AuthModal = ({
                     <Button onClick={() => login()}>Log in with Google</Button>
                     or
                     <Text>Enter your Learn Prompting Plus email</Text>
-                    <Input placeholder="example@mail.com" type="email" ref={emailInput}>
+                    <InputGroup size="sm">
+                        <Input placeholder="example@mail.com" type="email" ref={emailInput} />
                         <InputRightElement width="4.5rem">
                             <Button
                                 h="1.75rem"
@@ -58,7 +60,7 @@ const AuthModal = ({
                                 Submit
                             </Button>
                         </InputRightElement>
-                    </Input>
+                    </InputGroup>
                 </ModalBody>
                 <ModalFooter />
             </ModalContent>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -36,8 +36,7 @@ const AuthModal = ({
 
         if (whitelisted) {
             localStorage.setItem("whitelisted_email", email)
-            queryClient.invalidateQueries()
-            location.reload()
+            queryClient.invalidateQueries({ queryKey: ["checkWhitelisted"] })
         }
     }
 

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -36,6 +36,7 @@ const AuthModal = ({
 
         if (whitelisted) {
             localStorage.setItem("whitelisted_email", email)
+            queryClient.invalidateQueries()
             location.reload()
         }
     }

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -7,23 +7,37 @@ import {
     ModalBody,
     ModalFooter,
     Button,
+    Input,
+    Text,
+    InputRightElement,
 } from "@chakra-ui/react"
-import { useGoogleLogin } from '@react-oauth/google'
-import { queryClient } from '../util'
+import { useGoogleLogin } from "@react-oauth/google"
+import { queryClient, useCheckWhitelist } from "../util"
+import { useRef } from "react"
 
 const AuthModal = ({
     onComplete,
     ...props
 }: Omit<ModalProps, "children"> & { onComplete: (apiKey: string) => void }) => {
+    const emailInput = useRef<HTMLInputElement>(null!)
 
     const login = useGoogleLogin({
-        onSuccess: tokenResponse => {
-            localStorage.setItem('token', tokenResponse.access_token)
+        onSuccess: (tokenResponse) => {
+            localStorage.setItem("token", tokenResponse.access_token)
             queryClient.invalidateQueries()
             location.reload()
         },
-    });
+    })
 
+    const checkWhitelisted = (email: string) => {
+        const whitelisted = useCheckWhitelist(email)
+
+        if (whitelisted) {
+            localStorage.setItem("whitelisted_email", email)
+            queryClient.invalidateQueries()
+            location.reload()
+        }
+    }
 
     return (
         <Modal size="xl" {...props}>
@@ -31,9 +45,20 @@ const AuthModal = ({
             <ModalContent>
                 <ModalHeader>Please log in</ModalHeader>
                 <ModalBody>
-                    <Button onClick={() => login()}>
-                        Log in with Google
-                    </Button>
+                    <Button onClick={() => login()}>Log in with Google</Button>
+                    or
+                    <Text>Enter your Learn Prompting Plus email</Text>
+                    <Input placeholder="example@mail.com" type="email" ref={emailInput}>
+                        <InputRightElement width="4.5rem">
+                            <Button
+                                h="1.75rem"
+                                size="sm"
+                                onClick={(e) => checkWhitelisted(emailInput.current.value || "")}
+                            >
+                                Submit
+                            </Button>
+                        </InputRightElement>
+                    </Input>
                 </ModalBody>
                 <ModalFooter />
             </ModalContent>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -64,8 +64,9 @@ const AuthModal = ({
                     <Stack>
                         <Flex direction={"column"} align={"center"}>
                             <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
-                            <InputGroup size="sm" w={"60%"} mt={2} borderRadius={"md"}>
+                            <InputGroup size="sm" w={"60%"} mt={2}>
                                 <Input
+                                    borderRadius={"md"}
                                     placeholder="example@mail.com"
                                     type="email"
                                     ref={emailInput}

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -14,6 +14,8 @@ import {
     Center,
     useToast,
     Heading,
+    Stack,
+    Flex,
 } from "@chakra-ui/react"
 import { useGoogleLogin } from "@react-oauth/google"
 import { queryClient, client } from "../util"
@@ -59,26 +61,28 @@ const AuthModal = ({
             <ModalContent>
                 <ModalHeader>Please log in</ModalHeader>
                 <ModalBody>
-                    <Center>
-                        <Button onClick={() => login()}>Log in with Google</Button>
-                        <Heading size="sm"> or </Heading>
-                        <br />
-                        <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
-                        <InputGroup size="sm" w={"60%"}>
-                            <Input
-                                placeholder="example@mail.com"
-                                type="email"
-                                ref={emailInput}
-                                variant="filled"
-                                p={2}
-                            />
-                            <InputRightElement width="4.5rem" p={2}>
-                                <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>
-                                    Submit
-                                </Button>
-                            </InputRightElement>
-                        </InputGroup>
-                    </Center>
+                    <Stack>
+                        <Flex direction={"column"} align={"center"}>
+                            <Button onClick={() => login()}>Log in with Google</Button>
+                            <Heading size="sm"> or </Heading>
+                            <br />
+                            <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
+                            <InputGroup size="sm" w={"60%"}>
+                                <Input
+                                    placeholder="example@mail.com"
+                                    type="email"
+                                    ref={emailInput}
+                                    variant="filled"
+                                    p={2}
+                                />
+                                <InputRightElement width="4.5rem" p={2}>
+                                    <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>
+                                        Submit
+                                    </Button>
+                                </InputRightElement>
+                            </InputGroup>
+                        </Flex>
+                    </Stack>
                 </ModalBody>
                 <ModalFooter />
             </ModalContent>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -63,10 +63,6 @@ const AuthModal = ({
                 <ModalBody>
                     <Stack>
                         <Flex direction={"column"} align={"center"}>
-                            <Button onClick={() => login()}>Log in with Google</Button>
-                            <br />
-                            <Heading size="sm"> or </Heading>
-                            <br />
                             <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
                             <InputGroup size="sm" w={"60%"} mt={2} borderRadius={"md"}>
                                 <Input
@@ -82,6 +78,10 @@ const AuthModal = ({
                                     </Button>
                                 </InputRightElement>
                             </InputGroup>
+                            <br />
+                            <Heading size="sm"> or </Heading>
+                            <br />
+                            <Button onClick={() => login()}>Log in with Google</Button>
                         </Flex>
                     </Stack>
                 </ModalBody>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -13,6 +13,7 @@ import {
     InputGroup,
     Center,
     useToast,
+    Heading,
 } from "@chakra-ui/react"
 import { useGoogleLogin } from "@react-oauth/google"
 import { queryClient, client } from "../util"
@@ -59,10 +60,13 @@ const AuthModal = ({
                 <ModalHeader>Please log in</ModalHeader>
                 <ModalBody>
                     <Button onClick={() => login()}>Log in with Google</Button>
-                    <Center> or </Center>
-                    <Text>Enter your Learn Prompting Plus email</Text>
+                    <Center>
+                        {" "}
+                        <Heading size="sm"> or </Heading>{" "}
+                    </Center>
+                    <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
                     <InputGroup size="sm">
-                        <Input placeholder="example@mail.com" type="email" ref={emailInput} />
+                        <Input placeholder="example@mail.com" type="email" ref={emailInput} variant="filled" p={2} />
                         <InputRightElement width="4.5rem">
                             <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>
                                 Submit

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -36,7 +36,6 @@ const AuthModal = ({
 
         if (whitelisted) {
             localStorage.setItem("whitelisted_email", email)
-            queryClient.invalidateQueries({ queryKey: ["checkWhitelisted"] })
         }
     }
 

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -71,6 +71,11 @@ const AuthModal = ({
                                     ref={emailInput}
                                     variant="filled"
                                     p={2}
+                                    onKeyDown={async (e) => {
+                                        if (e.key === "Enter") {
+                                            await checkWhitelisted()
+                                        }
+                                    }}
                                 />
                                 <InputRightElement width="4.5rem" p={1}>
                                     <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -64,10 +64,11 @@ const AuthModal = ({
                     <Stack>
                         <Flex direction={"column"} align={"center"}>
                             <Button onClick={() => login()}>Log in with Google</Button>
+                            <br />
                             <Heading size="sm"> or </Heading>
                             <br />
                             <Heading size="sm">Enter your Learn Prompting Plus email</Heading>
-                            <InputGroup size="sm" w={"60%"}>
+                            <InputGroup size="sm" w={"60%"} mt={2} borderRadius={"md"}>
                                 <Input
                                     placeholder="example@mail.com"
                                     type="email"
@@ -75,7 +76,7 @@ const AuthModal = ({
                                     variant="filled"
                                     p={2}
                                 />
-                                <InputRightElement width="4.5rem" p={2}>
+                                <InputRightElement width="4.5rem" p={1}>
                                     <Button h="1.75rem" size="sm" onClick={async () => await checkWhitelisted()}>
                                         Submit
                                     </Button>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -40,7 +40,7 @@ const AuthModal = ({
 
         if (whitelisted) {
             localStorage.setItem("whitelisted_email", email)
-            queryClient.invalidateQueries({ queryKey: ["checkWhitelisted"] })
+            queryClient.invalidateQueries()
             location.reload()
         } else {
             toast({

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -11,6 +11,7 @@ import {
     Text,
     InputRightElement,
     InputGroup,
+    Center,
 } from "@chakra-ui/react"
 import { useGoogleLogin } from "@react-oauth/google"
 import { queryClient, useCheckWhitelist } from "../util"
@@ -35,7 +36,6 @@ const AuthModal = ({
 
         if (whitelisted) {
             localStorage.setItem("whitelisted_email", email)
-            queryClient.invalidateQueries()
             location.reload()
         }
     }
@@ -47,7 +47,7 @@ const AuthModal = ({
                 <ModalHeader>Please log in</ModalHeader>
                 <ModalBody>
                     <Button onClick={() => login()}>Log in with Google</Button>
-                    or
+                    <Center> or </Center>
                     <Text>Enter your Learn Prompting Plus email</Text>
                     <InputGroup size="sm">
                         <Input placeholder="example@mail.com" type="email" ref={emailInput} />

--- a/src/pages/EmbedPage.tsx
+++ b/src/pages/EmbedPage.tsx
@@ -18,10 +18,10 @@ const EmbedPage = () => {
     const { config: initialConfig, error } = useSearchParamConfig()
     const [config, setConfig] = useState<UrlConfig>(initialConfig ?? urlConfigSchema.getDefault())
     const [generating, setGenerating] = useState(false)
+    const [whitelisted, setWhitelisted] = useState(false)
 
     const apiKey = useApiKey()
     const isLoggedIn = useIsLoggedIn()
-    const whitelisted = useCheckWhitelist()
     const { mutate } = useEditApiKey()
 
     const generateWhitelistCompletion = async (): Promise<string> => {
@@ -110,6 +110,10 @@ const EmbedPage = () => {
         })
     }
 
+    useEffect(() => {
+        const isWhitelisted = useCheckWhitelist()
+        setWhitelisted(isWhitelisted)
+    }, [])
     useEffect(() => {
         // if the input has just closed & we are still generating,
         // then that means they inputted their API key and now we

--- a/src/pages/EmbedPage.tsx
+++ b/src/pages/EmbedPage.tsx
@@ -29,6 +29,8 @@ const EmbedPage = () => {
 
         if (res.status == 500) {
             throw new Error("no response text available")
+        } else if (res.status === 401) {
+            throw new Error(`Provided Whitelist Email is invalid => ${localStorage.getItem("whitelisted_email")}`)
         }
 
         const responseText = await res.text()

--- a/src/pages/EmbedPage.tsx
+++ b/src/pages/EmbedPage.tsx
@@ -18,10 +18,10 @@ const EmbedPage = () => {
     const { config: initialConfig, error } = useSearchParamConfig()
     const [config, setConfig] = useState<UrlConfig>(initialConfig ?? urlConfigSchema.getDefault())
     const [generating, setGenerating] = useState(false)
-    const [whitelisted, setWhitelisted] = useState(false)
 
     const apiKey = useApiKey()
     const isLoggedIn = useIsLoggedIn()
+    const whitelisted = useCheckWhitelist()
     const { mutate } = useEditApiKey()
 
     const generateWhitelistCompletion = async (): Promise<string> => {
@@ -110,10 +110,6 @@ const EmbedPage = () => {
         })
     }
 
-    useEffect(() => {
-        const isWhitelisted = useCheckWhitelist()
-        setWhitelisted(isWhitelisted)
-    }, [])
     useEffect(() => {
         // if the input has just closed & we are still generating,
         // then that means they inputted their API key and now we

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -166,22 +166,22 @@ const HomePage = () => {
                     <Heading size="lg">Workflow</Heading>
                     <Box>
                         <Text>
-                            When generating ouput for the first time, users will be prompted to sign in with their
-                            Google account.
+                            When generating ouput for the first time, users will be prompted to enter their email
+                            associated with their Learn Prompting Plus (LP Plus) account. If a user is not a LP Plus
+                            member, they can also sign in with their Google account.
                         </Text>
                         <br />
                         <Text>
-                            Whitelisted users (those with an active Learn Prompting Plus membership) enjoy a streamlined
-                            experience as they do not need to enter an API key. Their membership status is automatically
-                            recognized when logging in with their associated email, allowing them to focus on creating
-                            and testing prompts without any additional setup.
+                            Whitelisted users (those with an active LP Plus membership) enjoy a streamlined experience
+                            as they do not need to enter an API key. Their membership status is automatically recognized
+                            when logging in with their associated email, allowing them to focus on creating and testing
+                            prompts without any additional setup.
                         </Text>
                         <br />
                         <Text>
-                            For users who are not Learn Prompting Plus members, an additional step is required. After
-                            signing in with Google, they will be prompted to enter their OpenAI API key. This key is
-                            necessary for the embed to communicate with the user's OpenAI account and can be found in
-                            the user's{" "}
+                            For users who are not LP Plus members, an additional step is required. After signing in with
+                            Google, they will be prompted to enter their OpenAI API key. This key is necessary for the
+                            embed to communicate with the user's OpenAI account and can be found in the user's{" "}
                             <Link
                                 to="https://platform.openai.com/api-keys"
                                 target="_blank"
@@ -195,9 +195,10 @@ const HomePage = () => {
                         <Text>
                             This initial setup step ensures that the user's OpenAI API key is securely stored and
                             automatically applied in future sessions, eliminating the need to re-enter the key each
-                            time. After a successful login, a cookie will be stored in the user's browser. While the
-                            cookie is still valid, users will automatically be authenticated. When the cookie expires,
-                            the user will have to login with their google account again.
+                            time. After a successful login, their session details will be stored in localStorage. While
+                            the session is still valid, users will automatically be authenticated. When the session
+                            expires, the user will have to provide their LP Plus associated email or login with their
+                            google account again.
                         </Text>
                         <br />
                         <Text>

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,70 +1,77 @@
-import {
-  QueryClient,
-  useMutation,
-  useSuspenseQuery,
-} from '@tanstack/react-query'
-import ky from 'ky'
-import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
-import { persistQueryClient, removeOldestQuery } from '@tanstack/react-query-persist-client'
-
+import { QueryClient, useMutation, useSuspenseQuery } from "@tanstack/react-query"
+import ky from "ky"
+import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister"
+import { persistQueryClient, removeOldestQuery } from "@tanstack/react-query-persist-client"
 
 export const client = ({ signal }: { signal?: AbortSignal } = { signal: undefined }) =>
-  ky.extend({
-    prefixUrl: import.meta.env.VITE_SERVER_HOST,
-    headers: {
-      authorization: `Bearer ${typeof window === 'object' && localStorage.getItem('token')
-        }`,
-    },
-    signal,
-    throwHttpErrors: true,
-    timeout: 30000,
-  })
+    ky.extend({
+        prefixUrl: import.meta.env.VITE_SERVER_HOST,
+        headers: {
+            authorization: `Bearer ${typeof window === "object" && localStorage.getItem("token")}`,
+            "X-Whitelisted-Email": (typeof window === "object" && localStorage.getItem("whitelisted_email")) || "",
+        },
+        signal,
+        throwHttpErrors: true,
+        timeout: 30000,
+    })
 
 export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchInterval: 1560,
-      staleTime: 1000,
-      retry: true,
-      retryDelay: 1000,
+    defaultOptions: {
+        queries: {
+            refetchInterval: 1560,
+            staleTime: 1000,
+            retry: true,
+            retryDelay: 1000,
+        },
     },
-  },
 })
 
-
 const localStoragePersister = createSyncStoragePersister({
-  storage: window.localStorage,
+    storage: window.localStorage,
 })
 
 persistQueryClient({
-  queryClient,
-  persister: localStoragePersister,
+    queryClient,
+    persister: localStoragePersister,
 })
 
-export const useIsLoggedIn = () => useSuspenseQuery({
-  queryKey: ['isLoggedIn'],
-  queryFn: () => {
-    const token = localStorage.getItem('token')
-    return !!token
-  }
-}).data!
+export const useIsLoggedIn = () =>
+    useSuspenseQuery({
+        queryKey: ["isLoggedIn"],
+        queryFn: () => {
+            const token = localStorage.getItem("token")
+            const whitelistedEmail = localStorage.getItem("whitelisted_email")
+            return !!token || !!whitelistedEmail
+        },
+    }).data!
 
+export const useCheckWhitelist = (email?: string) =>
+    useSuspenseQuery({
+        queryKey: ["checkWhitelisted"],
+        queryFn: async () => {
+            const emailToCheck = localStorage.getItem("whitelisted_email") ?? email
+            const res = client().post("whitelisted", { json: { email: emailToCheck || "" } })
+            const { whitelisted }: { whitelisted: boolean } = await res.json()
+            return whitelisted
+        },
+    }).data!
 
+export const useApiKey = () =>
+    useSuspenseQuery({
+        queryKey: ["apiKey"],
+        queryFn: async () => localStorage.getItem("apiKey"),
+    }).data!
 
-export const useApiKey = () => useSuspenseQuery({
-  queryKey: ['apiKey'],
-  queryFn: async () => localStorage.getItem('apiKey')
-}).data!
-
-export const useEditApiKey = () => useMutation({
-  mutationKey: ['apiKey'],
-  mutationFn: (apiKey: string) => client().put('apiKey', { json: { apiKey: apiKey } }),
-  onMutate: async (newApiKey) => {
-    localStorage.setItem('apiKey', newApiKey)
-    queryClient.setQueryData(['apiKey'], newApiKey)
-    return newApiKey
-  },
-  onSettled: () => {
-    queryClient.invalidateQueries()
-  }
-})
+export const useEditApiKey = () =>
+    useMutation({
+        mutationKey: ["apiKey"],
+        mutationFn: (apiKey: string) => client().put("apiKey", { json: { apiKey: apiKey } }),
+        onMutate: async (newApiKey) => {
+            localStorage.setItem("apiKey", newApiKey)
+            queryClient.setQueryData(["apiKey"], newApiKey)
+            return newApiKey
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries()
+        },
+    })

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -45,12 +45,12 @@ export const useIsLoggedIn = () =>
         },
     }).data!
 
-export const useCheckWhitelist = (email?: string) =>
+export const useCheckWhitelist = () =>
     useSuspenseQuery({
         queryKey: ["checkWhitelisted"],
         queryFn: async () => {
-            const emailToCheck = localStorage.getItem("whitelisted_email") ?? email
-            const res = client().post("whitelisted", { json: { email: emailToCheck || "" } })
+            const emailToCheck = localStorage.getItem("whitelisted_email") || ""
+            const res = client().post("whitelisted", { json: { email: emailToCheck } })
             const { whitelisted }: { whitelisted: boolean } = await res.json()
             return whitelisted
         },

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -49,12 +49,8 @@ export const useCheckWhitelist = () =>
     useSuspenseQuery({
         queryKey: ["checkWhitelisted"],
         queryFn: async () => {
-            const emailToCheck = localStorage.getItem("whitelisted_email") || ""
-            const { whitelisted }: { whitelisted: boolean } = await client()
-                .post("whitelisted", { json: { email: emailToCheck } })
-                .json()
-
-            return whitelisted
+            const whitelisted = localStorage.getItem("whitelisted_email")
+            return !!whitelisted
         },
         staleTime: 60,
     }).data!

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -8,7 +8,7 @@ export const client = ({ signal }: { signal?: AbortSignal } = { signal: undefine
         prefixUrl: import.meta.env.VITE_SERVER_HOST,
         headers: {
             authorization: `Bearer ${typeof window === "object" && localStorage.getItem("token")}`,
-            "X-Whitelisted-Email": (typeof window === "object" && localStorage.getItem("whitelisted_email")) || "",
+            "X-Whitelisted-Email": `${typeof window === "object" && localStorage.getItem("whitelisted_email")}`,
         },
         signal,
         throwHttpErrors: true,

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -56,6 +56,7 @@ export const useCheckWhitelist = () =>
 
             return whitelisted
         },
+        staleTime: 60,
     }).data!
 
 export const useApiKey = () =>

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -50,8 +50,10 @@ export const useCheckWhitelist = () =>
         queryKey: ["checkWhitelisted"],
         queryFn: async () => {
             const emailToCheck = localStorage.getItem("whitelisted_email") || ""
-            const res = client().post("whitelisted", { json: { email: emailToCheck } })
-            const { whitelisted }: { whitelisted: boolean } = await res.json()
+            const { whitelisted }: { whitelisted: boolean } = await client()
+                .post("whitelisted", { json: { email: emailToCheck } })
+                .json()
+
             return whitelisted
         },
     }).data!


### PR DESCRIPTION
-Added authentication for all LP plus members, not just gmail.
-LP plus members can enter their email and use the embed with no configuration
-Their whitelisted email is stored in localstorage, and attached in header to all requests to the lp-embed-server
-lp-embed-server then checks email to see if valid LP plus member
-if valid, then lp-embed-server does server-side gpt generation using config sent to whitelistedGeneration endpoint and sends resulting output back to client